### PR TITLE
Added ability to change direct chats name and avatar

### DIFF
--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -634,7 +634,7 @@ class Portal(DBPortal, BasePortal):
         if self.is_direct:
             initial_state.append({
                 "type": "m.room.power_levels",
-                "content": {"users": {self.bridge_info.get('creator'): 100},
+                "content": {"users": {self.main_intent.mxid: 100},
                             "events": {"m.room.avatar": 0, "m.room.name": 0}}
             })
 

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -630,6 +630,13 @@ class Portal(DBPortal, BasePortal):
                 "type": "m.room.related_groups",
                 "content": {"groups": [self.config["appservice.community_id"]]},
             })
+        #Allow chaning of room avatar and name in direct chats
+        if self.is_direct:
+            initial_state.append({
+                "type": "m.room.power_levels",
+                "content": {"users": {self.bridge_info.get('creator'): 100},
+                            "events": {"m.room.avatar": 0, "m.room.name": 0}}
+            })
 
         self.mxid = await self.main_intent.create_room(name=name, is_direct=self.is_direct,
                                                        initial_state=initial_state,


### PR DESCRIPTION
The "clean" method with "power_level_content_override" is not working, so this is the workaround. Looks cleaner that way anyway.