### PR TITLE
Automatically reconnect to signald

### DIFF
--- a/mausignald/errors.py
+++ b/mausignald/errors.py
@@ -27,6 +27,10 @@ class LinkingError(RPCError):
         self.number = number
 
 
+class NotConnected(RPCError):
+    pass
+
+
 class LinkingTimeout(LinkingError):
     pass
 


### PR DESCRIPTION
If the signald socket gets disconnected (e.g., signald restart), we will
now retry reconnecting to the socket forever, with a 5 second wait
between attempts.  We will also retry the initial connect forever if the
socket connection fails on startup.

This change creates a couple "synthetic" RPC events for connect and
disconnect that handlers can be attached to, as well as a NotConnected
exception class.  These should help callers deal with the fact that the
client may not always be connected.

I think creating these synthetic events that aren't triggered by messages from signald may be a little awkward.  But we need some way for library callers to register callbacks for reconnections, and using the existing handler code in rpc.py seems like the cleanest solution to me.  Happy to re-work this if you prefer something else.

I've done a little bit of manual testing, and this seems to work well.  We still lose any messages sent from matrix while disconnected.  But it should now be easy to buffer these failed messages and send after reconnect.

Fixes #18 