### PR TITLE
Provide fallback for sticker image if not supplied by signald

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ RUN apk add --no-cache \
       ca-certificates \
       su-exec \
       # encryption
+      libressl \
       olm-dev \
       py3-cffi \
-	  py3-pycryptodome \
+      py3-pycryptodome \
       py3-unpaddedbase64 \
       py3-future \
       bash \
@@ -33,7 +34,7 @@ RUN apk add --no-cache \
 COPY requirements.txt /opt/mautrix-signal/requirements.txt
 COPY optional-requirements.txt /opt/mautrix-signal/optional-requirements.txt
 WORKDIR /opt/mautrix-signal
-RUN apk add --virtual .build-deps python3-dev libffi-dev build-base \
+RUN apk add --virtual .build-deps python3-dev libffi-dev libressl-dev build-base \
  && pip3 install -r requirements.txt -r optional-requirements.txt \
  && apk del .build-deps
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ yarl>=1,<2
 attrs>=19.1
 mautrix>=0.8,<0.9
 asyncpg>=0.20,<0.22
+signalstickers-client>=3.0


### PR DESCRIPTION
This will download received sticker images directly from Signal via https://github.com/signalstickers/signalstickers-client as signald currently does not provide an attachment for stickers (at least for me and #12)

Fixes #12

Maybe the [better solution](https://gitlab.com/signald/signald/-/issues/113) would be for signald to provide the sticker image, so feel free to discard at will ;) 