### PR TITLE
Fix iOS bug to display image/webp (stickers, messages)

### DIFF
--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -496,6 +496,9 @@ class Portal(DBPortal, BasePortal):
         content.url = await intent.upload_media(data, mime_type=upload_mime_type, filename=id)
         if content.file:
             content.file.url = content.url
+            # fix ios bug
+            if content.info.mimetype.startswith("image/"):
+                content.info.thumbnail_file = content.file
             content.url = None
 
     async def handle_signal_reaction(self, sender: 'p.Puppet', reaction: Reaction) -> None:


### PR DESCRIPTION
Duplicate 'file' section into 'info.thumbnail_file' in order for iOS to display properly webp images.

It works for stickers and message.

Without this patch, no webp image is displayed on iOS.

This can be removed after a fix on this issue: https://github.com/vector-im/element-ios/issues/4004