### PR TITLE
Added Captcha-Usage information

### DIFF
--- a/mautrix_signal/commands/auth.py
+++ b/mautrix_signal/commands/auth.py
@@ -82,7 +82,7 @@ async def link(evt: CommandEvent) -> None:
                  help_text="Sign into Signal as the primary device", help_args="<phone>")
 async def register(evt: CommandEvent) -> None:
     if len(evt.args) == 0:
-        await evt.reply("**Usage**: $cmdprefix+sp register [--voice] <phone>")
+        await evt.reply("**Usage**: $cmdprefix+sp register [--voice] [-c captcha-url after https://bit.ly/3izzhu8 redirection] <phone>")
         return
     voice = False
     captcha = None


### PR DESCRIPTION
would have saved me hours.

Used a shorter link to keep the help command relatively short - the link goes to https://signalcaptchas.org/registration/generate.html